### PR TITLE
Fix ArticleService delete method

### DIFF
--- a/src/api/article/services/article.ts
+++ b/src/api/article/services/article.ts
@@ -43,8 +43,8 @@ export abstract class BaseService<T extends UID.ContentType> {
     return this.base.update(id, params);
   }
 
-  async delete(params) {
-    return this.base?.find(params);
+  async delete(id, params) {
+    return this.base.delete(id, params);
   }
 }
 


### PR DESCRIPTION
## Summary
- fix ArticleService's delete method to actually call `base.delete` instead of `base.find`